### PR TITLE
optionally name shards in python api

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ shard_h5ad("large_atlas.h5ad", "atlas", shard_size=20000, shuffle=True, seed=0)
 # Gzip-compressed shards — smaller files at the cost of write speed
 shard_h5ad("large_atlas.h5ad", "atlas", shard_size=20000, compression="gzip")
 
+# Custom output filenames — provide explicit paths instead of auto-generated names
+shard_h5ad(
+    "large_atlas.h5ad",
+    "atlas",  # ignored when output_filenames is provided
+    shard_size=20000,
+    output_filenames=["batch_0.h5ad", "batch_1.h5ad", "batch_2.h5ad"],
+)
+
 # Merge shards back into one file (identical-var fast path used automatically)
 merge_out_of_core(["atlas_shard_0.h5ad", "atlas_shard_1.h5ad"], "merged.h5ad")
 

--- a/src/annslicer/slice.py
+++ b/src/annslicer/slice.py
@@ -55,6 +55,7 @@ def _open_zarr_backed(input_file: str) -> ad.AnnData:
 def shard_h5ad(
     input_file: str,
     output_prefix: str,
+    output_filenames: list[str] | None = None,
     shard_size: int = 10000,
     shuffle: bool = False,
     seed: int | None = None,
@@ -78,6 +79,11 @@ def shard_h5ad(
     output_prefix:
         Prefix for output shard filenames, e.g. ``"dataset"`` produces
         ``dataset_shard_0.h5ad``, ``dataset_shard_1.h5ad``, etc.
+    output_filenames:
+        Optional list of output shard filenames to write, e.g.
+        ``["shard_a.h5ad", "shard_b.h5ad", ...]``.  If provided, overrides the default naming scheme based on
+        ``output_prefix`` and ``shard_size``.  Must be the same length as the number of shards needed to
+        cover all cells in the input file.
     shard_size:
         Number of cells (rows) per shard. Defaults to 10 000.
     shuffle:
@@ -100,7 +106,9 @@ def shard_h5ad(
         adata = ad.read_h5ad(input_file, backed="r")
 
     try:
-        _shard_store(adata, output_prefix, shard_size, shuffle, seed, compression)
+        _shard_store(
+            adata, output_prefix, output_filenames, shard_size, shuffle, seed, compression
+        )
     finally:
         if hasattr(adata, "file") and adata.file.is_open:
             adata.file.close()
@@ -114,6 +122,7 @@ def _unwrap(arr: np.ndarray) -> Any:
 def _shard_store(
     adata: ad.AnnData,
     output_prefix: str,
+    output_filenames: list[str] | None,
     shard_size: int,
     shuffle: bool,
     seed: int | None,
@@ -127,6 +136,15 @@ def _shard_store(
     indices are sorted prior to reading (sequential I/O), then reordered in
     memory into the target permutation order, avoiding random disk seeks.
     """
+    if (
+        output_filenames is not None
+        and len(output_filenames) < (adata.n_obs + shard_size - 1) // shard_size
+    ):
+        raise ValueError(
+            f"Not enough output filenames provided: expected at least "
+            f"{(adata.n_obs + shard_size - 1) // shard_size}, got {len(output_filenames)}"
+        )
+
     total_cells = adata.n_obs
 
     perm: np.ndarray | None = None
@@ -139,7 +157,11 @@ def _shard_store(
     for start_idx in range(0, total_cells, shard_size):
         end_idx = min(start_idx + shard_size, total_cells)
         shard_num = start_idx // shard_size
-        out_filename = f"{output_prefix}_shard_{shard_num}.h5ad"
+        out_filename = (
+            output_filenames[shard_num]
+            if output_filenames is not None
+            else f"{output_prefix}_shard_{shard_num}.h5ad"
+        )
         logger.info("  Writing %s (cells %d–%d)...", out_filename, start_idx, end_idx)
 
         if perm is not None:

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -5,6 +5,7 @@ Tests for annslicer.slice
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import anndata as ad
 import numpy as np
@@ -162,6 +163,53 @@ def test_shard_different_seeds_differ(synthetic_h5ad, tmp_path):
     names1 = ad.read_h5ad(list(sorted(tmp_path.glob("s1_shard*.h5ad")))[0]).obs_names.tolist()
     names2 = ad.read_h5ad(list(sorted(tmp_path.glob("s2_shard*.h5ad")))[0]).obs_names.tolist()
     assert names1 != names2, "Different seeds should (almost certainly) produce different shuffles"
+
+
+# ---------------------------------------------------------------------------
+# output_filenames tests
+# ---------------------------------------------------------------------------
+
+
+def test_output_filenames_respected(synthetic_h5ad, tmp_path):
+    """Custom output_filenames are used instead of the default naming scheme."""
+    n_shards = math.ceil(N_CELLS / SHARD_SIZE)
+    custom_names = [str(tmp_path / f"custom_{i:02d}.h5ad") for i in range(n_shards)]
+    shard_h5ad(
+        synthetic_h5ad,
+        str(tmp_path / "unused_prefix"),
+        output_filenames=custom_names,
+        shard_size=SHARD_SIZE,
+    )
+
+    for path in custom_names:
+        assert Path(path).exists(), f"Expected shard file {path} was not created"
+
+
+def test_output_filenames_cell_counts(synthetic_h5ad, tmp_path):
+    """Shards written to custom filenames contain the expected number of cells."""
+    n_shards = math.ceil(N_CELLS / SHARD_SIZE)
+    custom_names = [str(tmp_path / f"named_{i}.h5ad") for i in range(n_shards)]
+    shard_h5ad(
+        synthetic_h5ad, str(tmp_path / "p"), output_filenames=custom_names, shard_size=SHARD_SIZE
+    )
+
+    all_obs: list[str] = []
+    for path in custom_names:
+        adata = ad.read_h5ad(path)
+        assert adata.n_obs == SHARD_SIZE
+        all_obs.extend(adata.obs_names.tolist())
+
+    assert len(all_obs) == N_CELLS
+    assert len(set(all_obs)) == N_CELLS
+
+
+def test_output_filenames_too_few_raises(synthetic_h5ad, tmp_path):
+    """Passing fewer filenames than shards raises ValueError."""
+    too_few = [str(tmp_path / "only_one.h5ad")]
+    with pytest.raises(ValueError, match="Not enough output filenames"):
+        shard_h5ad(
+            synthetic_h5ad, str(tmp_path / "p"), output_filenames=too_few, shard_size=SHARD_SIZE
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Enable someone using the python api (not command line) to specify exact output filenames as a list.  Skip this option for the command line tool.