### PR TITLE
add filter command, allow obs column sharding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ __pycache__/
 *.pyd
 *.so
 
+# adobe illustrator
+*.ai
+
+# vscode
+.vscode/
+
 # Distribution / packaging
 dist/
 build/

--- a/README.md
+++ b/README.md
@@ -9,26 +9,38 @@
 
 ![Diagram](diagram.png)
 
-Large single-cell datasets stored as `.h5ad` or `.zarr` files can easily exceed available RAM. `annslicer` slices them into manageable shards — and merges them back — without loading full matrices into memory. It uses best practices from `anndata` with a few small speed improvements for random shuffling.
+Large single-cell datasets stored as `.h5ad` or `.zarr` files can easily exceed available RAM. `annslicer` filters them, slices them into manageable shards and merges them back — without loading full matrices into memory. It uses best practices from `anndata` with a few small speed improvements for random shuffling.
 
 Consolidates best practices into a simple command-line tool.
 
 ```bash
-annslicer slice input.h5ad output_prefix
+annslicer slice input.h5ad output_prefix --size 10000
 ```
 
 ```bash
-annslicer merge output.h5ad shard_0.h5ad shard_1.h5ad
+annslicer slice input.h5ad output_prefix --obs-column cell_type
+```
+
+```bash
+annslicer filter input.h5ad filtered.h5ad --obs-column keep
+```
+
+```bash
+annslicer merge output.h5ad shard_*.h5ad
 ```
 
 ## Features
 
-- Shards and merges `X`, all `layers`, `obs`, `var`, `obsm`, and `uns`
+- Shards, filters, and merges `X`, all `layers`, `obs`, `var`, `obsm`, and `uns`
 - Handles both dense and sparse (CSR) matrices
 - Constant, low memory footprint regardless of file size
-- Input supports both `.h5ad` and `.zarr` formats for slicing
+- Input supports both `.h5ad` and `.zarr` formats for slicing and filtering
 - Merge output supports both `.h5ad` and `.zarr` formats
-- Optional **cell shuffling** (`--shuffle`) for representative shards without loading the full matrix
+- **Fixed-size sharding** (`--size`) with optional random cell shuffling
+- **Categorical sharding** (`--obs-column`) — one shard per category value, named by category
+- **Always-include cells** — append control cells (e.g. non-targeting controls) to every shard
+- **Auxiliary CSV metadata** — provide extra `obs` columns from a CSV file without modifying the source
+- **Cell filtering** — keep only cells matching a boolean obs column, out-of-core
 - Simple CLI and Python API
 
 ## Installation
@@ -45,9 +57,15 @@ pip install annslicer[zarr]
 
 ## CLI Usage
 
-`annslicer` provides two subcommands: `slice` and `merge`.
+`annslicer` provides three subcommands: `slice`, `filter`, and `merge`.
 
 ### Sharding a large file
+
+`annslicer slice` supports two sharding modes: fixed-size (default) and categorical.
+
+#### Fixed-size sharding
+
+Split the file into equal-sized shards by cell count:
 
 ```bash
 annslicer slice input.h5ad output_prefix --size 10000
@@ -58,7 +76,7 @@ Both `.h5ad` and `.zarr` inputs are supported.
 | Argument | Description |
 |---|---|
 | `input.h5ad` or `input.zarr` | Path to the source file |
-| `output_prefix` | Prefix for output files (e.g. `atlas` → `atlas_shard001.h5ad`, …) |
+| `output_prefix` | Prefix for output files (e.g. `atlas` → `atlas_shard_0.h5ad`, …) |
 | `--size N` | Number of cells per shard (default: `10000`) |
 | `--shuffle` | Randomly assign cells to shards (each shard is a representative draw) |
 | `--seed N` | Random seed for reproducible shuffling (requires `--shuffle`) |
@@ -70,7 +88,7 @@ Both `.h5ad` and `.zarr` inputs are supported.
 annslicer slice /data/large_atlas.h5ad /outputs/atlas --size 20000
 ```
 
-**Example — shuffled sharding from a large h5ad:**
+**Example — shuffled sharding:**
 
 ```bash
 annslicer slice /data/large_atlas.h5ad /outputs/atlas --size 10000 --shuffle --seed 0
@@ -83,6 +101,77 @@ annslicer slice /data/large_atlas.h5ad /outputs/atlas --size 10000 --compression
 ```
 
 Produces: `atlas_shard_0.h5ad`, `atlas_shard_1.h5ad`, …
+
+#### Categorical sharding by obs column
+
+Split cells into one shard per category value, named by the category:
+
+```bash
+annslicer slice input.h5ad output_prefix --obs-column cell_type
+```
+
+| Argument | Description |
+|---|---|
+| `--obs-column COLUMN` | Categorical obs column to partition on |
+| `--csv-file PATH` | Optional CSV file with extra per-cell metadata (see below) |
+| `--join-column COLUMN` | Column in the CSV to use as the cell-barcode key (default: first column) |
+| `--always-include VALUE [VALUE ...]` | Category values to copy into **every** shard (e.g. non-targeting controls); no dedicated file is written for these categories |
+| `--compression FILTER` | HDF5 compression filter; default: no compression |
+
+The `--obs-column` column must be a pandas `Categorical`. If the column comes from `--csv-file`, it is coerced to categorical automatically.
+
+**Example — shard a perturbation dataset by perturbation, including controls in every shard:**
+
+```bash
+annslicer slice perturb.h5ad /outputs/perturb \
+    --obs-column perturbation \
+    --always-include non-targeting
+```
+
+Produces: `perturb_KRAS.h5ad`, `perturb_TP53.h5ad`, … (one file per non-control perturbation, each containing the perturbation's cells plus all `non-targeting` cells).
+
+**Example — obs column from an auxiliary CSV:**
+
+```bash
+annslicer slice atlas.h5ad /outputs/atlas \
+    --obs-column tissue \
+    --csv-file metadata.csv
+```
+
+The CSV must contain one row per cell. Its first column (or `--join-column`) is matched to the h5ad obs index. All CSV columns are coerced to categorical.
+
+### Filtering cells
+
+Produce a single output file containing only cells for which a boolean obs column is `True`:
+
+```bash
+annslicer filter input.h5ad filtered.h5ad --obs-column keep
+```
+
+| Argument | Description |
+|---|---|
+| `input_file` | Path to the source `.h5ad` or `.zarr` file |
+| `output_file` | Path for the filtered output `.h5ad` file |
+| `--obs-column COLUMN` | *(required)* Column whose truthy values determine which cells to keep |
+| `--csv-file PATH` | Optional CSV file with extra per-cell metadata |
+| `--join-column COLUMN` | Column in the CSV to use as the cell-barcode key (default: first column) |
+| `--compression FILTER` | HDF5 compression filter; default: no compression |
+
+The filter column is interpreted leniently: `bool` dtype is used directly; numeric columns treat non-zero as `True`; string columns accept `"true"`/`"false"`/`"1"`/`"0"` (case-insensitive).
+
+**Example — filter using a pre-existing obs column:**
+
+```bash
+annslicer filter atlas.h5ad atlas_qc_pass.h5ad --obs-column qc_pass
+```
+
+**Example — filter using a column from an auxiliary CSV:**
+
+```bash
+annslicer filter atlas.h5ad atlas_filtered.h5ad \
+    --obs-column keep \
+    --csv-file cell_flags.csv
+```
 
 ### Merging shards back into one file
 
@@ -119,7 +208,9 @@ When shards have **different gene sets**, `--join outer` (default) takes the uni
 ## Python API
 
 ```python
-from annslicer import shard_h5ad, merge_out_of_core
+from annslicer import shard_h5ad, shard_by_obs_column, filter_h5ad, merge_out_of_core
+
+# --- Fixed-size sharding ---
 
 # Basic sharding (h5ad or zarr input)
 shard_h5ad("large_atlas.h5ad", "atlas", shard_size=20000)
@@ -139,6 +230,38 @@ shard_h5ad(
     output_filenames=["batch_0.h5ad", "batch_1.h5ad", "batch_2.h5ad"],
 )
 
+# --- Categorical sharding by obs column ---
+
+# Shard by a categorical obs column — one file per category, named by category value
+shard_by_obs_column("atlas.h5ad", "atlas", obs_column="tissue")
+# Produces: atlas_brain.h5ad, atlas_liver.h5ad, atlas_lung.h5ad, …
+
+# Perturbation dataset — include control cells in every shard
+shard_by_obs_column(
+    "perturb.h5ad",
+    "perturb",
+    obs_column="perturbation",
+    always_include=["non-targeting"],
+)
+
+# Obs column from an auxiliary CSV (coerced to categorical automatically)
+shard_by_obs_column(
+    "atlas.h5ad",
+    "atlas",
+    obs_column="tissue",
+    csv_file="metadata.csv",  # first column matched to obs index
+)
+
+# --- Filtering ---
+
+# Keep only cells where obs column is truthy (bool, 0/1, or 'True'/'False' strings)
+filter_h5ad("atlas.h5ad", "atlas_qc.h5ad", obs_column="qc_pass")
+
+# Filter using a boolean column from an auxiliary CSV
+filter_h5ad("atlas.h5ad", "atlas_filtered.h5ad", obs_column="keep", csv_file="flags.csv")
+
+# --- Merging ---
+
 # Merge shards back into one file (identical-var fast path used automatically)
 merge_out_of_core(["atlas_shard_0.h5ad", "atlas_shard_1.h5ad"], "merged.h5ad")
 
@@ -151,12 +274,25 @@ merge_out_of_core(["shard_a.h5ad", "shard_b.h5ad"], "merged.h5ad", join="inner")
 
 ## How it works
 
-### Slicing
+### Fixed-size slicing
 1. Opens the input file ("backed" AnnData for `.h5ad`; `anndata.io.sparse_dataset` for `.zarr`).
 2. If `shuffle=True`, generates a global cell permutation upfront using `numpy.random.default_rng`.
 3. For each shard, reads only the relevant rows from `X` and each layer via sorted fancy indexing — no full matrix is ever loaded into memory.
 4. When shuffling, rows are read in sorted index order (maximising sequential I/O) and then reordered in-memory to the desired shuffled order.
 5. Reassembles a valid `AnnData` object per shard and writes it to disk.
+
+### Categorical slicing
+1. Opens the input file in the same backed/lazy mode as fixed-size slicing.
+2. If `--csv-file` is provided, reads the CSV and merges it into `adata.obs` in memory (the backing file is never written to). All new columns are coerced to categorical.
+3. Validates that the target column is categorical. Validates that any `--always-include` values exist in the category list.
+4. Sanitises category names to safe filename fragments (`re.sub(r'[^\w.-]', '_', name)`); raises an error if two names collide after sanitisation.
+5. For each non-always-include category: collects cell indices via `numpy.where`, appends always-include indices, sorts for sequential I/O, then writes. Empty categories are skipped with a warning.
+
+### Filtering
+1. Opens the input file in backed/lazy mode.
+2. Optionally merges an auxiliary CSV into `adata.obs` (same merge logic as categorical slicing).
+3. Reads the filter column and coerces it to boolean leniently (bool → direct; numeric → non-zero; string → `'true'`/`'false'`/`'1'`/`'0'`).
+4. Collects the indices of cells where the column is `True` and writes them to a new file.
 
 ### Merging
 1. Reads `obs`, `var`, and `uns` from **all** shards to build a skeleton output file.

--- a/src/annslicer/__init__.py
+++ b/src/annslicer/__init__.py
@@ -10,7 +10,8 @@ except PackageNotFoundError:
     # Package is not installed (e.g. running from source without install)
     __version__ = "unknown"
 
+from annslicer.filter import filter_h5ad
 from annslicer.merge import merge_out_of_core
-from annslicer.slice import shard_h5ad
+from annslicer.slice import shard_by_obs_column, shard_h5ad
 
-__all__ = ["shard_h5ad", "merge_out_of_core"]
+__all__ = ["shard_h5ad", "shard_by_obs_column", "filter_h5ad", "merge_out_of_core"]

--- a/src/annslicer/_common.py
+++ b/src/annslicer/_common.py
@@ -1,0 +1,149 @@
+"""
+Shared helpers for annslicer: out-of-core shard writing and CSV obs merging.
+
+Used by both ``slice.py`` and ``filter.py`` to avoid code duplication.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def _unwrap(arr: np.ndarray) -> Any:
+    """Unwrap the 0-d object array that h5py sometimes returns for backed sparse layers."""
+    return arr.item() if isinstance(arr, np.ndarray) and arr.ndim == 0 else arr
+
+
+def _write_shard_from_indices(
+    adata: ad.AnnData,
+    indices: np.ndarray,
+    out_filename: str,
+    compression: str | None = None,
+) -> None:
+    """
+    Write a subset of an AnnData object (identified by integer row indices) to a
+    new .h5ad file.
+
+    Indices are sorted before reading so that disk access is sequential (efficient
+    for both HDF5 and zarr backends).  The output preserves the source order — cells
+    appear in the same relative order as they do in the input file.
+
+    Parameters
+    ----------
+    adata:
+        An already-opened (backed or in-memory) AnnData object.
+    indices:
+        Integer row indices to include.  Need not be sorted; they will be sorted
+        internally before reading and the output will be in ascending index order.
+    out_filename:
+        Destination .h5ad path.
+    compression:
+        HDF5 compression filter (e.g. ``"gzip"``).  ``None`` writes uncompressed.
+    """
+    sorted_idx = np.sort(indices)
+
+    X = _unwrap(adata.X[sorted_idx, :])
+    layers = {k: _unwrap(adata.layers[k][sorted_idx, :]) for k in adata.layers}
+    obsm = {k: np.asarray(adata.obsm[k][sorted_idx]) for k in adata.obsm}
+    obs = adata.obs.iloc[sorted_idx]
+
+    ad.AnnData(
+        X=X,
+        obs=obs.copy(),
+        var=adata.var.copy(),
+        obsm=obsm,
+        layers=layers,
+        uns=adata.uns.copy(),
+    ).write_h5ad(out_filename, compression=compression)
+
+
+def _merge_csv_into_obs(
+    obs_df: pd.DataFrame,
+    csv_file: str,
+    join_column: str | None = None,
+) -> pd.DataFrame:
+    """
+    Read an auxiliary CSV file and left-join its columns onto an obs DataFrame.
+
+    The CSV is joined on the obs index (cell barcodes).  By default the CSV's
+    first column is used as the join key (treated as the cell barcode index).
+    Pass ``join_column`` to use a named column instead.
+
+    After joining, any column whose dtype is not already categorical is coerced
+    to ``pd.CategoricalDtype``.  This ensures that columns sourced from a CSV
+    (which are typically read as plain strings or numbers) behave correctly when
+    used as the ``obs_column`` argument to :func:`shard_by_obs_column`.
+
+    Parameters
+    ----------
+    obs_df:
+        The existing ``adata.obs`` DataFrame (index = cell barcodes).
+    csv_file:
+        Path to the CSV file containing additional per-cell metadata.
+    join_column:
+        Name of the column in the CSV to use as the join key.  If ``None``,
+        the first column is used.
+
+    Returns
+    -------
+    pd.DataFrame
+        A new obs DataFrame with the CSV columns appended.
+
+    Raises
+    ------
+    ValueError
+        If any cell barcode present in ``obs_df`` is absent from the CSV.
+    """
+    csv_df = pd.read_csv(csv_file)
+
+    if join_column is not None:
+        csv_df = csv_df.set_index(join_column)
+    else:
+        csv_df = csv_df.set_index(csv_df.columns[0])
+
+    # Normalise the CSV index to plain Python strings.
+    #
+    # pd.read_csv may infer the join-key column as int64 when barcodes look
+    # numeric (e.g. "1", "2", …), which would silently break a join against a
+    # string obs index.  Stripping whitespace guards against trailing spaces in
+    # either the CSV or the h5ad obs index.
+    csv_df.index = csv_df.index.astype(str).str.strip()
+
+    # Normalise the obs index to plain Python strings for comparison and joining.
+    #
+    # AnnData obs indices are almost always string-valued, but the backing dtype
+    # can differ across anndata / pandas versions: "object" (Python str), or the
+    # newer pandas StringDtype (arrow-backed).  Using .astype(str) produces a
+    # consistent object-dtype index that joins correctly with the CSV index.
+    obs_index_str = obs_df.index.astype(str).str.strip()
+
+    # Validate: every obs barcode must appear in the CSV.
+    missing = obs_index_str.difference(csv_df.index)
+    if len(missing) > 0:
+        missing_list = ", ".join(str(m) for m in sorted(missing)[:20])
+        suffix = f" ... ({len(missing) - 20} more)" if len(missing) > 20 else ""
+        raise ValueError(
+            f"The auxiliary CSV is missing {len(missing)} cell barcode(s) that are "
+            f"present in the h5ad obs index: {missing_list}{suffix}.\n"
+            f"Ensure the CSV contains a row for every cell in the input file."
+        )
+
+    # Coerce all non-categorical columns in the CSV portion to CategoricalDtype so
+    # that string/int columns from a CSV can be used directly as obs_column for
+    # shard_by_obs_column without requiring the user to pre-cast the column.
+    for col in csv_df.columns:
+        if not isinstance(csv_df[col].dtype, pd.CategoricalDtype):
+            csv_df[col] = csv_df[col].astype("category")
+
+    # Join on the normalised string index; restore the original index object
+    # afterwards so the returned DataFrame has the same index dtype as the input.
+    result = obs_df.set_axis(obs_index_str).join(csv_df, how="left")
+    result.index = obs_df.index
+    return result

--- a/src/annslicer/_store.py
+++ b/src/annslicer/_store.py
@@ -59,3 +59,22 @@ def _is_sparse_group(store: Store, key: str) -> bool:
     # For both h5py.Group and zarr.Group the presence of 'data' + 'indptr'
     # sub-keys indicates a sparse CSR representation.
     return "data" in item and "indptr" in item
+
+
+def _store_create_array(
+    group: Store,
+    name: str,
+    *,
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+    dtype: object,
+) -> object:
+    """Create an array/dataset in *group*, compatible with h5py, zarr v2, and zarr v3.
+
+    zarr v3 renamed ``Group.create_dataset`` to ``Group.create_array``.  This
+    wrapper tries ``create_array`` first (zarr v3 and any h5py shim that exposes
+    it) and falls back to ``create_dataset`` (zarr v2 and h5py).
+    """
+    if hasattr(group, "create_array"):
+        return group.create_array(name, shape=shape, chunks=chunks, dtype=dtype)  # type: ignore[union-attr]
+    return group.create_dataset(name, shape=shape, chunks=chunks, dtype=dtype)  # type: ignore[union-attr]

--- a/src/annslicer/cli.py
+++ b/src/annslicer/cli.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 import argparse
 import logging
 
-from annslicer import merge, slice
 from annslicer import filter as filter_mod
+from annslicer import merge, slice
 
 
 def main() -> None:

--- a/src/annslicer/cli.py
+++ b/src/annslicer/cli.py
@@ -13,6 +13,7 @@ import argparse
 import logging
 
 from annslicer import merge, slice
+from annslicer import filter as filter_mod
 
 
 def main() -> None:
@@ -36,6 +37,7 @@ def main() -> None:
 
     slice.register_subcommand(subparsers)
     merge.register_subcommand(subparsers)
+    filter_mod.register_subcommand(subparsers)
 
     args = parser.parse_args()
 

--- a/src/annslicer/filter.py
+++ b/src/annslicer/filter.py
@@ -1,0 +1,182 @@
+"""
+Core logic for annslicer: out-of-core filtering of .h5ad / .zarr files.
+
+Produces a single output file containing only the cells for which a boolean
+obs column (or auxiliary CSV column) evaluates to True.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+from annslicer._common import _merge_csv_into_obs, _write_shard_from_indices
+from annslicer.slice import _open_zarr_backed
+
+logger = logging.getLogger(__name__)
+
+
+def filter_h5ad(
+    input_file: str,
+    output_file: str,
+    obs_column: str,
+    csv_file: str | None = None,
+    join_column: str | None = None,
+    compression: str | None = None,
+) -> None:
+    """
+    Filter a large .h5ad or .zarr file to a single output file containing only
+    the cells for which ``obs_column`` is truthy.
+
+    The filter column is interpreted leniently:
+
+    - ``bool`` dtype — used directly.
+    - Numeric dtype — ``True`` wherever the value is non-zero.
+    - Object / string dtype — ``"true"`` / ``"1"`` map to ``True``;
+      ``"false"`` / ``"0"`` map to ``False``.  Any other value raises a
+      ``ValueError`` listing the unrecognised entries.
+
+    Parameters
+    ----------
+    input_file:
+        Path to the source .h5ad or .zarr file.
+    output_file:
+        Destination path for the filtered .h5ad file.
+    obs_column:
+        Column in ``adata.obs`` (or in the auxiliary CSV) whose values
+        determine which cells to keep.
+    csv_file:
+        Optional path to a CSV file with extra per-cell metadata.  Merged
+        into ``adata.obs`` before filtering.  Columns from the CSV that are
+        not already categorical are automatically coerced to
+        ``pd.CategoricalDtype`` (useful when the CSV column is later used as
+        an obs_column for :func:`shard_by_obs_column`).
+    join_column:
+        Column in the CSV to use as the cell-barcode join key.  Defaults to
+        the CSV's first column.
+    compression:
+        HDF5 compression filter for the output file (e.g. ``"gzip"``).
+    """
+    if input_file.endswith(".zarr"):
+        logger.info("Opening zarr store %s in backed mode via sparse_dataset...", input_file)
+        adata = _open_zarr_backed(input_file)
+    else:
+        logger.info("Opening %s in backed mode...", input_file)
+        adata = ad.read_h5ad(input_file, backed="r")
+
+    try:
+        _filter_store(adata, output_file, obs_column, csv_file, join_column, compression)
+    finally:
+        if hasattr(adata, "file") and adata.file.is_open:
+            adata.file.close()
+
+
+def _filter_store(
+    adata: ad.AnnData,
+    output_file: str,
+    obs_column: str,
+    csv_file: str | None,
+    join_column: str | None,
+    compression: str | None,
+) -> None:
+    """Core logic for :func:`filter_h5ad` operating on an open AnnData."""
+    # --- Merge auxiliary CSV into obs if provided ---
+    if csv_file is not None:
+        adata.obs = _merge_csv_into_obs(adata.obs, csv_file, join_column)
+
+    col = adata.obs[obs_column]
+
+    # --- Lenient boolean coercion ---
+    if col.dtype == bool or pd.api.types.is_bool_dtype(col):
+        bool_col = col
+    elif pd.api.types.is_numeric_dtype(col):
+        bool_col = col != 0
+    else:
+        # Object / string column: map known truthy/falsy strings.
+        mapped = col.str.lower().map({"true": True, "false": False, "1": True, "0": False})
+        bad = col[mapped.isna()]
+        if len(bad) > 0:
+            bad_values = sorted(bad.unique().tolist())[:10]
+            raise ValueError(
+                f"Column {obs_column!r} contains values that cannot be interpreted as boolean: "
+                f"{bad_values}. Expected 'true', 'false', '1', or '0' (case-insensitive)."
+            )
+        bool_col = mapped.astype(bool)
+
+    keep_idx = np.where(bool_col)[0]
+    cells_in = adata.n_obs
+    cells_out = len(keep_idx)
+    logger.info(
+        "Filtering %s: %d cells in → %d cells out → %s",
+        "input",
+        cells_in,
+        cells_out,
+        output_file,
+    )
+    _write_shard_from_indices(adata, keep_idx, output_file, compression)
+    logger.info("Filter complete.")
+
+
+def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``filter`` subcommand on an existing subparsers action."""
+    p = subparsers.add_parser(
+        "filter",
+        help="Filter a large .h5ad or .zarr file to a single output file.",
+        description=(
+            "Out-of-core cell filtering: keep only cells for which a boolean "
+            "obs column (or auxiliary CSV column) is True.  The filter column "
+            "is interpreted leniently (bool, 0/1 int, or 'True'/'False' strings)."
+        ),
+    )
+    p.add_argument("input_file", help="Path to the input .h5ad or .zarr file.")
+    p.add_argument("output_file", help="Path for the filtered output .h5ad file.")
+    p.add_argument(
+        "--obs-column",
+        required=True,
+        metavar="COLUMN",
+        help="Column in obs (or auxiliary CSV) with boolean keep/discard values.",
+    )
+    p.add_argument(
+        "--csv-file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to an auxiliary CSV file with extra per-cell metadata. "
+            "Merged into obs before filtering (columns coerced to categorical)."
+        ),
+    )
+    p.add_argument(
+        "--join-column",
+        default=None,
+        metavar="COLUMN",
+        help=(
+            "Column in the CSV to use as the cell-barcode join key. "
+            "Defaults to the CSV's first column."
+        ),
+    )
+    p.add_argument(
+        "--compression",
+        default=None,
+        metavar="FILTER",
+        help=(
+            "HDF5 compression filter for the output file "
+            '(e.g. "gzip", "lzf"). Default: no compression.'
+        ),
+    )
+    p.set_defaults(func=_run)
+
+
+def _run(args: argparse.Namespace) -> None:
+    """Dispatch function called by the CLI after argument parsing."""
+    filter_h5ad(
+        args.input_file,
+        args.output_file,
+        args.obs_column,
+        csv_file=args.csv_file,
+        join_column=args.join_column,
+        compression=args.compression,
+    )

--- a/src/annslicer/merge.py
+++ b/src/annslicer/merge.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from anndata.io import read_elem
 
-from annslicer._store import _is_sparse_group, _require_zarr, open_store
+from annslicer._store import _is_sparse_group, _require_zarr, _store_create_array, open_store
 
 logger = logging.getLogger(__name__)
 
@@ -354,10 +354,12 @@ def merge_out_of_core(
         grp.attrs["shape"] = [int(total_cells), int(num_genes)]
 
         chunk_size = (min(total_nnz, 1_000_000),)
-        grp.create_dataset("data", shape=(total_nnz,), chunks=chunk_size, dtype=np.float32)
-        grp.create_dataset("indices", shape=(total_nnz,), chunks=chunk_size, dtype=np.int32)
+        _store_create_array(grp, "data", shape=(total_nnz,), chunks=chunk_size, dtype=np.float32)
+        _store_create_array(grp, "indices", shape=(total_nnz,), chunks=chunk_size, dtype=np.int32)
         indptr_chunk = (min(total_cells + 1, 100_000),)
-        grp.create_dataset("indptr", shape=(total_cells + 1,), chunks=indptr_chunk, dtype=np.int64)
+        _store_create_array(
+            grp, "indptr", shape=(total_cells + 1,), chunks=indptr_chunk, dtype=np.int64
+        )
 
     if "X" in matrix_nnz:
         allocate_sparse("X", matrix_nnz["X"])
@@ -366,7 +368,8 @@ def merge_out_of_core(
         if "X" in out_store:
             del out_store["X"]
         chunk_rows = min(total_cells, 1_000)
-        ds = out_store.create_dataset(
+        ds = _store_create_array(
+            out_store,
             "X",
             shape=(total_cells, num_genes),
             chunks=(chunk_rows, num_genes),
@@ -392,8 +395,12 @@ def merge_out_of_core(
             if key in grp_obsm:
                 del grp_obsm[key]
             obsm_chunk_rows = min(total_cells, 10_000)
-            grp_obsm.create_dataset(
-                key, shape=(total_cells, dim), chunks=(obsm_chunk_rows, dim), dtype=np.float32
+            _store_create_array(
+                grp_obsm,
+                key,
+                shape=(total_cells, dim),
+                chunks=(obsm_chunk_rows, dim),
+                dtype=np.float32,
             )
 
     # Streaming loop

--- a/src/annslicer/slice.py
+++ b/src/annslicer/slice.py
@@ -6,11 +6,14 @@ from __future__ import annotations
 
 import argparse
 import logging
+import re
 from typing import Any
 
 import anndata as ad
 import numpy as np
+import pandas as pd
 
+from annslicer._common import _merge_csv_into_obs, _unwrap, _write_shard_from_indices
 from annslicer._store import _require_zarr
 
 logger = logging.getLogger(__name__)
@@ -114,11 +117,6 @@ def shard_h5ad(
             adata.file.close()
 
 
-def _unwrap(arr: np.ndarray) -> Any:
-    """Unwrap the 0-d object array that h5py sometimes returns for backed sparse layers."""
-    return arr.item() if isinstance(arr, np.ndarray) and arr.ndim == 0 else arr
-
-
 def _shard_store(
     adata: ad.AnnData,
     output_prefix: str,
@@ -172,23 +170,173 @@ def _shard_store(
             layers = {k: _unwrap(adata.layers[k][sorted_idx, :])[restore] for k in adata.layers}
             obsm = {k: np.asarray(adata.obsm[k][sorted_idx])[restore] for k in adata.obsm}
             obs = adata.obs.iloc[orig_idx]
+            ad.AnnData(
+                X=X,
+                obs=obs.copy(),
+                var=adata.var.copy(),
+                obsm=obsm,
+                layers=layers,
+                uns=adata.uns.copy(),
+            ).write_h5ad(out_filename, compression=compression)
         else:
-            s = slice(start_idx, end_idx)
-            X = _unwrap(adata.X[s, :])
-            layers = {k: _unwrap(adata.layers[k][s, :]) for k in adata.layers}
-            obsm = {k: np.asarray(adata.obsm[k][s]) for k in adata.obsm}
-            obs = adata.obs.iloc[start_idx:end_idx]
-
-        ad.AnnData(
-            X=X,
-            obs=obs.copy(),
-            var=adata.var.copy(),
-            obsm=obsm,
-            layers=layers,
-            uns=adata.uns.copy(),
-        ).write_h5ad(out_filename, compression=compression)
+            _write_shard_from_indices(
+                adata,
+                np.arange(start_idx, end_idx, dtype=np.intp),
+                out_filename,
+                compression,
+            )
 
     logger.info("All shards successfully created.")
+
+
+def shard_by_obs_column(
+    input_file: str,
+    output_prefix: str,
+    obs_column: str,
+    csv_file: str | None = None,
+    join_column: str | None = None,
+    always_include: list[str] | None = None,
+    compression: str | None = None,
+) -> None:
+    """
+    Shard a large .h5ad or .zarr file by grouping cells according to a
+    categorical ``adata.obs`` column.
+
+    One output .h5ad file is produced per category (excluding any categories
+    listed in ``always_include``).  Output filenames are derived from the
+    category names rather than shard numbers:
+    ``{output_prefix}_{safe_category_name}.h5ad``.
+
+    Parameters
+    ----------
+    input_file:
+        Path to the source .h5ad or .zarr file.
+    output_prefix:
+        Prefix for output shard filenames.
+    obs_column:
+        Name of the column in ``adata.obs`` (or in the auxiliary CSV) to
+        partition on.  Must be (or be coercible to) a categorical dtype.
+    csv_file:
+        Optional path to a CSV file containing extra per-cell metadata.  The
+        CSV is merged into ``adata.obs`` before partitioning.  Columns from
+        the CSV that are not already categorical are automatically coerced to
+        ``pd.CategoricalDtype``.
+    join_column:
+        Column in the CSV to use as the join key (cell barcode).  Defaults to
+        the CSV's first column.
+    always_include:
+        One or more category values to append to *every* output shard.  Cells
+        belonging to these categories are copied into each shard but do not
+        produce a dedicated output file of their own.
+    compression:
+        HDF5 compression filter for output files (e.g. ``"gzip"``).
+    """
+    if input_file.endswith(".zarr"):
+        logger.info("Opening zarr store %s in backed mode via sparse_dataset...", input_file)
+        adata = _open_zarr_backed(input_file)
+    else:
+        logger.info("Opening %s in backed mode...", input_file)
+        adata = ad.read_h5ad(input_file, backed="r")
+
+    try:
+        _shard_by_obs_column_store(
+            adata,
+            output_prefix,
+            obs_column,
+            csv_file,
+            join_column,
+            always_include,
+            compression,
+        )
+    finally:
+        if hasattr(adata, "file") and adata.file.is_open:
+            adata.file.close()
+
+
+def _shard_by_obs_column_store(
+    adata: ad.AnnData,
+    output_prefix: str,
+    obs_column: str,
+    csv_file: str | None,
+    join_column: str | None,
+    always_include: list[str] | None,
+    compression: str | None,
+) -> None:
+    """Core logic for :func:`shard_by_obs_column` operating on an open AnnData."""
+    # --- Merge auxiliary CSV into obs if provided ---
+    if csv_file is not None:
+        adata.obs = _merge_csv_into_obs(adata.obs, csv_file, join_column)
+
+    # --- Validate obs_column is categorical ---
+    if obs_column not in adata.obs.columns:
+        raise KeyError(f"obs_column {obs_column!r} not found in adata.obs.")
+    obs_col = adata.obs[obs_column]
+    if not isinstance(obs_col.dtype, pd.CategoricalDtype):
+        raise ValueError(
+            f"obs_column {obs_column!r} has dtype {obs_col.dtype!r}, expected a categorical. "
+            f"Cast the column to a categorical before calling shard_by_obs_column, "
+            f"or provide it via --csv-file (CSV columns are coerced automatically)."
+        )
+
+    categories = list(obs_col.cat.categories)
+    always_include_set: set[str] = set(always_include) if always_include else set()
+
+    # --- Validate always_include values ---
+    if always_include_set:
+        unknown = always_include_set - set(categories)
+        if unknown:
+            raise ValueError(
+                f"always_include contains value(s) not found in category list: "
+                f"{sorted(unknown)}. Valid categories are: {categories}."
+            )
+
+    # --- Compute always-include indices ---
+    if always_include_set:
+        always_idx = np.where(obs_col.isin(always_include_set))[0]
+    else:
+        always_idx = np.array([], dtype=np.intp)
+
+    # --- Sanitize names and check for collisions ---
+    shard_categories = [c for c in categories if c not in always_include_set]
+    safe_names: dict[str, str] = {}  # category -> safe filename fragment
+    seen_safe: dict[str, str] = {}   # safe name -> original category (for collision detection)
+    for cat in shard_categories:
+        safe = re.sub(r"[^\w.-]", "_", str(cat))
+        if safe in seen_safe:
+            raise ValueError(
+                f"Category names {cat!r} and {seen_safe[safe]!r} both sanitize to the "
+                f"same filename fragment {safe!r}. Rename one of the categories so that "
+                f"their alphanumeric representations are distinct."
+            )
+        seen_safe[safe] = cat
+        safe_names[cat] = safe
+
+    # --- Write one shard per category ---
+    shards_written = 0
+    for cat in shard_categories:
+        cat_idx = np.where(obs_col == cat)[0]
+        if len(cat_idx) == 0:
+            logger.warning(
+                "Category %r has no cells — skipping (no output file will be written).", cat
+            )
+            continue
+
+        indices = np.sort(np.concatenate([cat_idx, always_idx]))
+        out_filename = f"{output_prefix}_{safe_names[cat]}.h5ad"
+        logger.info(
+            "  Writing %s (%d cells + %d always-include)...",
+            out_filename,
+            len(cat_idx),
+            len(always_idx),
+        )
+        _write_shard_from_indices(adata, indices, out_filename, compression)
+        shards_written += 1
+
+    logger.info(
+        "shard_by_obs_column complete: %d shards written for column %r.",
+        shards_written,
+        obs_column,
+    )
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -238,16 +386,64 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
             '(e.g. "gzip", "lzf"). Default: no compression.'
         ),
     )
+    p.add_argument(
+        "--obs-column",
+        default=None,
+        metavar="COLUMN",
+        help=(
+            "Partition cells by this categorical obs column instead of fixed-size shards. "
+            "Each category produces one output file named {output_prefix}_{category}.h5ad."
+        ),
+    )
+    p.add_argument(
+        "--csv-file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to an auxiliary CSV file with extra per-cell metadata. "
+            "Merged into obs before partitioning (columns coerced to categorical)."
+        ),
+    )
+    p.add_argument(
+        "--join-column",
+        default=None,
+        metavar="COLUMN",
+        help=(
+            "Column in the CSV to use as the cell-barcode join key. "
+            "Defaults to the CSV's first column."
+        ),
+    )
+    p.add_argument(
+        "--always-include",
+        nargs="+",
+        default=None,
+        metavar="VALUE",
+        help=(
+            "One or more category values to append to every output shard "
+            "(e.g. non-targeting control cells). Requires --obs-column."
+        ),
+    )
     p.set_defaults(func=_run)
 
 
 def _run(args: argparse.Namespace) -> None:
     """Dispatch function called by the CLI after argument parsing."""
-    shard_h5ad(
-        args.input_file,
-        args.output_prefix,
-        args.size,
-        shuffle=args.shuffle,
-        seed=args.seed,
-        compression=args.compression,
-    )
+    if args.obs_column is not None:
+        shard_by_obs_column(
+            args.input_file,
+            args.output_prefix,
+            args.obs_column,
+            csv_file=args.csv_file,
+            join_column=args.join_column,
+            always_include=args.always_include,
+            compression=args.compression,
+        )
+    else:
+        shard_h5ad(
+            args.input_file,
+            args.output_prefix,
+            shard_size=args.size,
+            shuffle=args.shuffle,
+            seed=args.seed,
+            compression=args.compression,
+        )

--- a/src/annslicer/slice.py
+++ b/src/annslicer/slice.py
@@ -299,7 +299,7 @@ def _shard_by_obs_column_store(
     # --- Sanitize names and check for collisions ---
     shard_categories = [c for c in categories if c not in always_include_set]
     safe_names: dict[str, str] = {}  # category -> safe filename fragment
-    seen_safe: dict[str, str] = {}   # safe name -> original category (for collision detection)
+    seen_safe: dict[str, str] = {}  # safe name -> original category (for collision detection)
     for cat in shard_categories:
         safe = re.sub(r"[^\w.-]", "_", str(cat))
         if safe in seen_safe:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,3 +98,46 @@ def synthetic_zarr(tmp_path_factory: pytest.TempPathFactory) -> str:
     zarr_path = str(out_dir / "synthetic.zarr")
     adata.write_zarr(zarr_path)
     return zarr_path
+
+
+@pytest.fixture(scope="session")
+def synthetic_csv_categorical(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """
+    Write a CSV with cell barcodes and a ``cell_type`` column matching the
+    synthetic h5ad fixture.  The column is written as plain strings (not
+    categorical) to verify that _merge_csv_into_obs coerces it automatically.
+
+    Returns the path to the CSV file.
+    """
+    import csv
+
+    rows = [["cell_id", "cell_type"]] + [
+        [f"cell_{i}", f"type_{i % 3}"] for i in range(N_CELLS)
+    ]
+    out_dir = tmp_path_factory.mktemp("csv_data")
+    csv_path = str(out_dir / "cell_types.csv")
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerows(rows)
+    return csv_path
+
+
+@pytest.fixture(scope="session")
+def synthetic_csv_bool(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """
+    Write a CSV with cell barcodes and a ``keep`` boolean column.
+    First 100 cells are True, last 50 are False.
+
+    Returns the path to the CSV file.
+    """
+    import csv
+
+    rows = [["cell_id", "keep"]] + [
+        [f"cell_{i}", i < 100] for i in range(N_CELLS)
+    ]
+    out_dir = tmp_path_factory.mktemp("csv_bool_data")
+    csv_path = str(out_dir / "keep_flags.csv")
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerows(rows)
+    return csv_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,9 +111,7 @@ def synthetic_csv_categorical(tmp_path_factory: pytest.TempPathFactory) -> str:
     """
     import csv
 
-    rows = [["cell_id", "cell_type"]] + [
-        [f"cell_{i}", f"type_{i % 3}"] for i in range(N_CELLS)
-    ]
+    rows = [["cell_id", "cell_type"]] + [[f"cell_{i}", f"type_{i % 3}"] for i in range(N_CELLS)]
     out_dir = tmp_path_factory.mktemp("csv_data")
     csv_path = str(out_dir / "cell_types.csv")
     with open(csv_path, "w", newline="") as f:
@@ -132,9 +130,7 @@ def synthetic_csv_bool(tmp_path_factory: pytest.TempPathFactory) -> str:
     """
     import csv
 
-    rows = [["cell_id", "keep"]] + [
-        [f"cell_{i}", i < 100] for i in range(N_CELLS)
-    ]
+    rows = [["cell_id", "keep"]] + [[f"cell_{i}", i < 100] for i in range(N_CELLS)]
     out_dir = tmp_path_factory.mktemp("csv_bool_data")
     csv_path = str(out_dir / "keep_flags.csv")
     with open(csv_path, "w", newline="") as f:

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -8,8 +8,6 @@ import csv
 from pathlib import Path
 
 import anndata as ad
-import numpy as np
-import pandas as pd
 import pytest
 
 from annslicer.filter import filter_h5ad
@@ -124,8 +122,9 @@ def test_filter_csv_missing_cells_raises(synthetic_h5ad, tmp_path):
             writer.writerow([f"cell_{i}", True])
 
     with pytest.raises(ValueError, match="missing"):
-        filter_h5ad(synthetic_h5ad, str(tmp_path / "out.h5ad"), obs_column="keep",
-                    csv_file=partial_csv)
+        filter_h5ad(
+            synthetic_h5ad, str(tmp_path / "out.h5ad"), obs_column="keep", csv_file=partial_csv
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +134,6 @@ def test_filter_csv_missing_cells_raises(synthetic_h5ad, tmp_path):
 
 def test_filter_zarr_input(synthetic_zarr, tmp_path):
     """filter_h5ad works with a zarr input."""
-    import anndata as ad_mod
     import anndata
 
     # zarr doesn't have a backed mode for writing only a subset of obs easily;

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,198 @@
+"""
+Tests for annslicer.filter
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+
+from annslicer.filter import filter_h5ad
+
+N_CELLS = 150
+N_GENES = 50
+N_KEEP = 100  # first 100 cells kept by the synthetic_csv_bool fixture
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _kept_cells() -> set[str]:
+    return {f"cell_{i}" for i in range(N_KEEP)}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def filtered_h5ad(synthetic_h5ad, tmp_path_factory):
+    """Filter the synthetic h5ad using the built-in 'keep' obs column and return the path."""
+    import anndata as ad_mod
+
+    # Add a boolean 'keep' column: True for first 100, False for last 50
+    adata = ad_mod.read_h5ad(synthetic_h5ad)
+    adata.obs["keep"] = [i < N_KEEP for i in range(N_CELLS)]
+    out_dir = tmp_path_factory.mktemp("filter_data")
+    with_keep = str(out_dir / "with_keep.h5ad")
+    adata.write_h5ad(with_keep)
+
+    out_path = str(out_dir / "filtered.h5ad")
+    filter_h5ad(with_keep, out_path, obs_column="keep")
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Basic correctness tests
+# ---------------------------------------------------------------------------
+
+
+def test_filter_output_exists(filtered_h5ad):
+    assert Path(filtered_h5ad).exists()
+
+
+def test_filter_cell_count(filtered_h5ad):
+    adata = ad.read_h5ad(filtered_h5ad)
+    assert adata.n_obs == N_KEEP
+
+
+def test_filter_correct_cells_kept(filtered_h5ad):
+    adata = ad.read_h5ad(filtered_h5ad)
+    assert set(adata.obs_names.tolist()) == _kept_cells()
+
+
+def test_filter_var_preserved(filtered_h5ad, synthetic_h5ad):
+    merged = ad.read_h5ad(filtered_h5ad)
+    original = ad.read_h5ad(synthetic_h5ad)
+    assert list(merged.var_names) == list(original.var_names)
+
+
+def test_filter_layer_present(filtered_h5ad):
+    adata = ad.read_h5ad(filtered_h5ad)
+    assert "counts" in adata.layers
+    assert adata.layers["counts"].shape == (N_KEEP, N_GENES)
+
+
+def test_filter_obsm_present(filtered_h5ad):
+    adata = ad.read_h5ad(filtered_h5ad)
+    assert "X_pca" in adata.obsm
+    assert adata.obsm["X_pca"].shape == (N_KEEP, 10)
+
+
+def test_filter_all_false_writes_empty(synthetic_h5ad, tmp_path):
+    """When all cells are False the output file has 0 cells."""
+    import anndata as ad_mod
+
+    adata = ad_mod.read_h5ad(synthetic_h5ad)
+    adata.obs["keep"] = False
+    alt = str(tmp_path / "all_false.h5ad")
+    adata.write_h5ad(alt)
+    out = str(tmp_path / "out.h5ad")
+    filter_h5ad(alt, out, obs_column="keep")
+    assert ad.read_h5ad(out).n_obs == 0
+
+
+# ---------------------------------------------------------------------------
+# CSV merge path
+# ---------------------------------------------------------------------------
+
+
+def test_filter_csv_merge(synthetic_h5ad, synthetic_csv_bool, tmp_path):
+    """CSV merge path keeps the same cells as using a built-in obs column."""
+    out = str(tmp_path / "filtered_csv.h5ad")
+    filter_h5ad(synthetic_h5ad, out, obs_column="keep", csv_file=synthetic_csv_bool)
+    adata = ad.read_h5ad(out)
+    assert adata.n_obs == N_KEEP
+    assert set(adata.obs_names.tolist()) == _kept_cells()
+
+
+def test_filter_csv_missing_cells_raises(synthetic_h5ad, tmp_path):
+    """ValueError when the CSV is missing some cell barcodes."""
+    partial_csv = str(tmp_path / "partial.csv")
+    with open(partial_csv, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["cell_id", "keep"])
+        for i in range(100):
+            writer.writerow([f"cell_{i}", True])
+
+    with pytest.raises(ValueError, match="missing"):
+        filter_h5ad(synthetic_h5ad, str(tmp_path / "out.h5ad"), obs_column="keep",
+                    csv_file=partial_csv)
+
+
+# ---------------------------------------------------------------------------
+# Zarr input
+# ---------------------------------------------------------------------------
+
+
+def test_filter_zarr_input(synthetic_zarr, tmp_path):
+    """filter_h5ad works with a zarr input."""
+    import anndata as ad_mod
+    import anndata
+
+    # zarr doesn't have a backed mode for writing only a subset of obs easily;
+    # read the zarr, add a keep column, write a temp h5ad, then use that as input.
+    adata = anndata.read_zarr(synthetic_zarr)
+    adata.obs["keep"] = [i < N_KEEP for i in range(N_CELLS)]
+    alt_zarr = str(tmp_path / "with_keep.zarr")
+    pytest.importorskip("zarr")
+    adata.write_zarr(alt_zarr)
+
+    out = str(tmp_path / "filtered.h5ad")
+    filter_h5ad(alt_zarr, out, obs_column="keep")
+    result = ad.read_h5ad(out)
+    assert result.n_obs == N_KEEP
+
+
+# ---------------------------------------------------------------------------
+# Lenient boolean coercion
+# ---------------------------------------------------------------------------
+
+
+def test_filter_bool_lenient_int(synthetic_h5ad, tmp_path):
+    """0/1 integer column is accepted as boolean."""
+    import anndata as ad_mod
+
+    adata = ad_mod.read_h5ad(synthetic_h5ad)
+    adata.obs["keep_int"] = [1 if i < N_KEEP else 0 for i in range(N_CELLS)]
+    alt = str(tmp_path / "int_keep.h5ad")
+    adata.write_h5ad(alt)
+
+    out = str(tmp_path / "out.h5ad")
+    filter_h5ad(alt, out, obs_column="keep_int")
+    assert ad.read_h5ad(out).n_obs == N_KEEP
+
+
+def test_filter_bool_lenient_string(synthetic_h5ad, tmp_path):
+    """'True'/'False' string column is accepted as boolean."""
+    import anndata as ad_mod
+
+    adata = ad_mod.read_h5ad(synthetic_h5ad)
+    adata.obs["keep_str"] = ["True" if i < N_KEEP else "False" for i in range(N_CELLS)]
+    alt = str(tmp_path / "str_keep.h5ad")
+    adata.write_h5ad(alt)
+
+    out = str(tmp_path / "out.h5ad")
+    filter_h5ad(alt, out, obs_column="keep_str")
+    assert ad.read_h5ad(out).n_obs == N_KEEP
+
+
+def test_filter_bool_invalid_strings_raise(synthetic_h5ad, tmp_path):
+    """Unmappable string values in the filter column raise ValueError."""
+    import anndata as ad_mod
+
+    adata = ad_mod.read_h5ad(synthetic_h5ad)
+    adata.obs["keep_bad"] = "yes"  # not a recognised boolean string
+    alt = str(tmp_path / "bad_keep.h5ad")
+    adata.write_h5ad(alt)
+
+    with pytest.raises(ValueError, match="cannot be interpreted as boolean"):
+        filter_h5ad(alt, str(tmp_path / "out.h5ad"), obs_column="keep_bad")

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -456,7 +456,6 @@ def test_obs_shard_sanitized_name_collision_raises(tmp_path):
     """ValueError when two category names sanitize to the same filename fragment."""
     import anndata as ad_mod
     import pandas as pd
-    import scipy.sparse as sp_mod
 
     rng = np.random.default_rng(0)
     # "foo bar" and "foo_bar" both sanitize to "foo_bar"

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 import scipy.sparse as sp
 
-from annslicer.slice import shard_h5ad
+from annslicer.slice import shard_by_obs_column, shard_h5ad
 
 # Match the constants from conftest.py
 N_CELLS = 150
@@ -271,3 +271,200 @@ def test_slice_zarr_input_shuffle(synthetic_zarr, tmp_path):
         all_indices.extend(ad.read_h5ad(path).obs_names.tolist())
     assert len(all_indices) == N_CELLS
     assert len(set(all_indices)) == N_CELLS
+
+
+# ---------------------------------------------------------------------------
+# shard_by_obs_column tests
+# ---------------------------------------------------------------------------
+
+# The synthetic_h5ad fixture has cell_type in {type_0, type_1, type_2}, 50 cells each.
+CATEGORIES = ["type_0", "type_1", "type_2"]
+N_PER_CATEGORY = 50
+
+
+def test_obs_shard_file_count(synthetic_h5ad, tmp_path):
+    """Exactly one output file per non-empty category."""
+    shard_by_obs_column(synthetic_h5ad, str(tmp_path / "out"), "cell_type")
+    files = list(tmp_path.glob("out_*.h5ad"))
+    assert len(files) == len(CATEGORIES)
+
+
+def test_obs_shard_filenames(synthetic_h5ad, tmp_path):
+    """Output filenames contain the category names."""
+    shard_by_obs_column(synthetic_h5ad, str(tmp_path / "out"), "cell_type")
+    names = {p.name for p in tmp_path.glob("out_*.h5ad")}
+    for cat in CATEGORIES:
+        assert f"out_{cat}.h5ad" in names, f"Expected file out_{cat}.h5ad"
+
+
+def test_obs_shard_cell_assignment(synthetic_h5ad, tmp_path):
+    """Every cell in a shard belongs to that shard's category."""
+    shard_by_obs_column(synthetic_h5ad, str(tmp_path / "out"), "cell_type")
+    for cat in CATEGORIES:
+        adata = ad.read_h5ad(tmp_path / f"out_{cat}.h5ad")
+        assert all(v == cat for v in adata.obs["cell_type"]), f"Unexpected cells in shard {cat}"
+
+
+def test_obs_shard_no_overlap(synthetic_h5ad, tmp_path):
+    """Non-always-include cells appear in exactly one shard."""
+    shard_by_obs_column(synthetic_h5ad, str(tmp_path / "out"), "cell_type")
+    all_cells: list[str] = []
+    for cat in CATEGORIES:
+        all_cells.extend(ad.read_h5ad(tmp_path / f"out_{cat}.h5ad").obs_names.tolist())
+    assert len(all_cells) == N_CELLS
+    assert len(set(all_cells)) == N_CELLS
+
+
+def test_obs_shard_full_coverage(synthetic_h5ad, tmp_path):
+    """Union of cells across all shards equals the full dataset."""
+    shard_by_obs_column(synthetic_h5ad, str(tmp_path / "out"), "cell_type")
+    all_cells: set[str] = set()
+    for path in tmp_path.glob("out_*.h5ad"):
+        all_cells.update(ad.read_h5ad(path).obs_names.tolist())
+    assert len(all_cells) == N_CELLS
+
+
+def test_obs_shard_var_preserved(synthetic_h5ad, tmp_path):
+    """var DataFrame is identical across all shards."""
+    shard_by_obs_column(synthetic_h5ad, str(tmp_path / "out"), "cell_type")
+    ref = ad.read_h5ad(tmp_path / f"out_{CATEGORIES[0]}.h5ad").var
+    for cat in CATEGORIES[1:]:
+        shard_var = ad.read_h5ad(tmp_path / f"out_{cat}.h5ad").var
+        assert ref.equals(shard_var)
+
+
+def test_obs_shard_non_categorical_raises(synthetic_h5ad, tmp_path):
+    """ValueError when the obs column is not categorical."""
+    import anndata as ad_mod
+
+    # Write a version with a numeric (non-categorical) column
+    adata = ad_mod.read_h5ad(synthetic_h5ad)
+    adata.obs["score"] = np.arange(N_CELLS, dtype=np.float32)
+    alt = str(tmp_path / "alt.h5ad")
+    adata.write_h5ad(alt)
+
+    with pytest.raises(ValueError, match="expected a categorical"):
+        shard_by_obs_column(alt, str(tmp_path / "out"), "score")
+
+
+def test_obs_shard_missing_column_raises(synthetic_h5ad, tmp_path):
+    """KeyError when the obs column doesn't exist."""
+    with pytest.raises(KeyError):
+        shard_by_obs_column(synthetic_h5ad, str(tmp_path / "out"), "nonexistent_column")
+
+
+def test_obs_shard_zarr_input(synthetic_zarr, tmp_path):
+    """shard_by_obs_column works with a zarr input file."""
+    shard_by_obs_column(synthetic_zarr, str(tmp_path / "out"), "cell_type")
+    files = list(tmp_path.glob("out_*.h5ad"))
+    assert len(files) == len(CATEGORIES)
+    all_cells: list[str] = []
+    for path in files:
+        all_cells.extend(ad.read_h5ad(path).obs_names.tolist())
+    assert len(all_cells) == N_CELLS
+    assert len(set(all_cells)) == N_CELLS
+
+
+def test_obs_shard_csv_merge(synthetic_h5ad, synthetic_csv_categorical, tmp_path):
+    """CSV merge path produces the same shards as using the built-in obs column."""
+    # Write a version of the h5ad that does NOT have cell_type in obs
+    import anndata as ad_mod
+
+    adata = ad_mod.read_h5ad(synthetic_h5ad)
+    adata.obs = adata.obs.drop(columns=["cell_type"])
+    no_cat = str(tmp_path / "no_cell_type.h5ad")
+    adata.write_h5ad(no_cat)
+
+    shard_by_obs_column(
+        no_cat,
+        str(tmp_path / "csv"),
+        "cell_type",
+        csv_file=synthetic_csv_categorical,
+    )
+    files = list(tmp_path.glob("csv_*.h5ad"))
+    assert len(files) == len(CATEGORIES)
+    all_cells: list[str] = []
+    for path in files:
+        all_cells.extend(ad.read_h5ad(path).obs_names.tolist())
+    assert len(set(all_cells)) == N_CELLS
+
+
+def test_obs_shard_csv_missing_cells_raises(synthetic_h5ad, tmp_path):
+    """ValueError when the CSV is missing cell barcodes present in the h5ad."""
+    import csv
+
+    # Write a CSV that only covers the first 100 cells
+    partial_csv = str(tmp_path / "partial.csv")
+    with open(partial_csv, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["cell_id", "cell_type"])
+        for i in range(100):
+            writer.writerow([f"cell_{i}", f"type_{i % 3}"])
+
+    with pytest.raises(ValueError, match="missing"):
+        shard_by_obs_column(
+            synthetic_h5ad,
+            str(tmp_path / "out"),
+            "cell_type",
+            csv_file=partial_csv,
+        )
+
+
+def test_obs_shard_always_include_in_every_shard(synthetic_h5ad, tmp_path):
+    """Cells from always_include categories appear in every output shard."""
+    # always_include = ["type_2"] → type_2 cells (cell_100..cell_149) appear in type_0 and type_1 shards
+    shard_by_obs_column(
+        synthetic_h5ad,
+        str(tmp_path / "out"),
+        "cell_type",
+        always_include=["type_2"],
+    )
+    always_cells = {f"cell_{i}" for i in range(N_CELLS) if i % 3 == 2}  # type_2 cells
+    for cat in ["type_0", "type_1"]:
+        shard_obs_names = set(ad.read_h5ad(tmp_path / f"out_{cat}.h5ad").obs_names.tolist())
+        assert always_cells.issubset(shard_obs_names), (
+            f"Always-include cells missing from shard {cat}"
+        )
+
+
+def test_obs_shard_always_include_no_dedicated_shard(synthetic_h5ad, tmp_path):
+    """No dedicated output file is written for always_include categories."""
+    shard_by_obs_column(
+        synthetic_h5ad,
+        str(tmp_path / "out"),
+        "cell_type",
+        always_include=["type_2"],
+    )
+    assert not (tmp_path / "out_type_2.h5ad").exists()
+    # Only two shards: type_0 and type_1
+    files = list(tmp_path.glob("out_*.h5ad"))
+    assert len(files) == 2
+
+
+def test_obs_shard_always_include_invalid_raises(synthetic_h5ad, tmp_path):
+    """ValueError for always_include values not in the category list."""
+    with pytest.raises(ValueError, match="always_include"):
+        shard_by_obs_column(
+            synthetic_h5ad,
+            str(tmp_path / "out"),
+            "cell_type",
+            always_include=["nonexistent_category"],
+        )
+
+
+def test_obs_shard_sanitized_name_collision_raises(tmp_path):
+    """ValueError when two category names sanitize to the same filename fragment."""
+    import anndata as ad_mod
+    import pandas as pd
+    import scipy.sparse as sp_mod
+
+    rng = np.random.default_rng(0)
+    # "foo bar" and "foo_bar" both sanitize to "foo_bar"
+    cats = pd.Categorical(["foo bar"] * 5 + ["foo_bar"] * 5)
+    obs = pd.DataFrame({"grp": cats}, index=[f"c{i}" for i in range(10)])
+    adata = ad_mod.AnnData(X=rng.random((10, 5), dtype=np.float32), obs=obs)
+    h5ad = str(tmp_path / "collision.h5ad")
+    adata.write_h5ad(h5ad)
+
+    with pytest.raises(ValueError, match="sanitize"):
+        shard_by_obs_column(h5ad, str(tmp_path / "out"), "grp")


### PR DESCRIPTION
Adds the `filter` subcommand: useful for people who have a large h5ad and want to filter it without loading it in memory.

Adds the ability to shard based on metadata from an `obs` column.  This produces shards with categorical values as filenames, and probably uneven shard sizes.  There is also the option to "always include" one or more categories in all shards.  (This is for a use case like perturb-seq, where you'd like all shards to include one perturbation plus all control cells.  In this case the shards are redundant, but it can be useful for downstream tasks.  Alternatively, you could simply shard on the perturbation obs column and then pass a single perturbation plus the non-targeting control shards as multiple files to downstream tasks.  User's choice.)

(Both of the above allow for cell metadata to be supplied in an auxiliary CSV file.  This is nice in cases where you've done some compute externally and have outputs, but don't want to open that massive h5ad file to add the annotations in.)