### PR TITLE
fix disparate var merge bug

### DIFF
--- a/src/annslicer/_common.py
+++ b/src/annslicer/_common.py
@@ -58,7 +58,7 @@ def _write_shard_from_indices(
     sorted_idx = np.sort(indices)
 
     X = _unwrap(adata.X[sorted_idx, :])
-    layers = {k: _unwrap(adata.layers[k][sorted_idx, :]) for k in adata.layers}
+    layers = {k: _unwrap(adata.layers[k][sorted_idx, :]) for k in adata.layers if k is not None}
     obsm = {k: np.asarray(adata.obsm[k][sorted_idx]) for k in adata.obsm}
     obs = adata.obs.iloc[sorted_idx]
 

--- a/src/annslicer/merge.py
+++ b/src/annslicer/merge.py
@@ -22,8 +22,37 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _is_increasing(a: np.ndarray) -> bool:
+    """True when *a* is strictly increasing (the selection order h5py requires)."""
+    return bool(a.size < 2 or np.all(np.diff(a) > 0))
+
+
+def _sort_indices_within_rows(
+    indices: np.ndarray, data: np.ndarray, row_nnz: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Restore the canonical CSR invariant of ascending column indices per row.
+
+    Remapping columns onto a merged var index permutes the column numbering, so
+    entries that were ascending in the shard's own numbering may not be
+    ascending in the merged numbering.  Sorting by ``(row, column)`` puts them
+    back in canonical order without moving entries across row boundaries.
+
+    Parameters
+    ----------
+    indices, data:
+        Flat CSR arrays for one shard, already remapped.
+    row_nnz:
+        Number of stored entries per row (``np.diff`` of the local indptr).
+    """
+    if len(indices) == 0:
+        return indices, data
+    row_ids = np.repeat(np.arange(len(row_nnz), dtype=np.int64), row_nnz)
+    order = np.lexsort((indices, row_ids))
+    return indices[order], data[order]
+
+
 def _compute_merged_var(
-    var_frames: list[pd.DataFrame], join: str
+    var_frames: list[pd.DataFrame], join: str, shard_names: list[str] | None = None
 ) -> tuple[pd.DataFrame, list[np.ndarray], bool]:
     """Compute the merged var DataFrame and per-shard column remaps.
 
@@ -33,6 +62,8 @@ def _compute_merged_var(
         var DataFrames, one per shard, in shard order.
     join:
         ``"inner"`` or ``"outer"``.
+    shard_names:
+        Optional shard paths, used only to make error messages actionable.
 
     Returns
     -------
@@ -45,6 +76,12 @@ def _compute_merged_var(
     is_identity : bool
         ``True`` when all shards share the identical var (fast path — no
         remapping required).
+
+    Raises
+    ------
+    ValueError
+        If a shard needing a remap has duplicate ``var_names``, or if the join
+        produces an empty var.
     """
     from functools import reduce
 
@@ -54,6 +91,27 @@ def _compute_merged_var(
     if all(idx.equals(indices[0]) for idx in indices[1:]):
         identity = np.arange(len(indices[0]), dtype=np.int32)
         return var_frames[0], [identity] * len(var_frames), True
+
+    # Past this point every shard's columns are remapped onto the merged index,
+    # which needs an unambiguous old-column -> new-column mapping.  Duplicate
+    # gene names make that mapping ill-defined and yield a repeated column
+    # selection, which h5py rejects outright.  Fail early, naming the shard.
+    # (The identity fast path above is a plain concatenation that needs no
+    # mapping, so duplicates stay legal there and merges that work today keep
+    # working.)
+    for i, idx in enumerate(indices):
+        if idx.has_duplicates:
+            dups = idx[idx.duplicated()].unique().tolist()
+            shown = ", ".join(repr(d) for d in dups[:5])
+            more = f", … (+{len(dups) - 5} more)" if len(dups) > 5 else ""
+            where = f"'{shard_names[i]}'" if shard_names is not None else f"at position {i}"
+            raise ValueError(
+                f"Shard {where} has duplicate var_names: {shown}{more}. "
+                f"Merging shards whose gene sets differ requires unique gene names "
+                f"in every shard, because each shard's columns must be remapped onto "
+                f"the merged var index. Call `adata.var_names_make_unique()` on the "
+                f"offending shard(s) and re-run."
+            )
 
     if join == "inner":
         merged_index = reduce(lambda a, b: a.intersection(b), indices)
@@ -109,9 +167,19 @@ def _write_remapped_sparse(
 
     new_indices = remap[old_indices]
 
+    # The merged var index is sorted while each shard's var is in its own
+    # arbitrary order, so `remap` is usually non-monotonic.  That permutes the
+    # column numbering and breaks the CSR sorted-indices invariant, which
+    # anndata and scipy consumers assume.  Re-sort each row when it can happen.
+    remap_is_increasing = _is_increasing(remap[remap >= 0])
+
     if join == "outer":
         # All entries are kept; only column positions change.
         shard_nnz = len(old_data)
+        if not remap_is_increasing:
+            new_indices, old_data = _sort_indices_within_rows(
+                new_indices, old_data, np.diff(old_indptr)
+            )
         out_store[path]["data"][current_nnz : current_nnz + shard_nnz] = old_data  # type: ignore[index]
         out_store[path]["indices"][current_nnz : current_nnz + shard_nnz] = new_indices  # type: ignore[index]
         shifted_indptr = old_indptr + current_nnz
@@ -133,6 +201,11 @@ def _write_remapped_sparse(
 
     new_local_indptr = np.concatenate([[0], np.cumsum(new_row_nnz)])
     shard_surviving = int(mask.sum())
+
+    if not remap_is_increasing:
+        surviving_indices, surviving_data = _sort_indices_within_rows(
+            surviving_indices, surviving_data, new_row_nnz
+        )
 
     out_store[path]["data"][current_nnz : current_nnz + shard_surviving] = surviving_data  # type: ignore[index]
     out_store[path]["indices"][current_nnz : current_nnz + shard_surviving] = surviving_indices  # type: ignore[index]
@@ -268,7 +341,7 @@ def merge_out_of_core(
         if hasattr(store_first, "close"):
             store_first.close()
 
-    merged_var, col_remaps, is_identity = _compute_merged_var(var_frames, join)
+    merged_var, col_remaps, is_identity = _compute_merged_var(var_frames, join, input_files)
     num_genes: int = len(merged_var)
 
     # Only merge layers present in *every* shard; absent layers would produce
@@ -438,15 +511,27 @@ def merge_out_of_core(
                 shard_X = in_store["X"][:]
                 if is_identity:
                     out_store["X"][current_cell : current_cell + num_cells_in_shard, :] = shard_X
-                elif join == "inner":
-                    valid = remap >= 0
-                    out_store["X"][  # type: ignore[index]
-                        current_cell : current_cell + num_cells_in_shard, remap[valid]
-                    ] = shard_X[:, valid]
                 else:
+                    if join == "inner":
+                        valid = remap >= 0
+                        selection = remap[valid]
+                        block = shard_X[:, valid]
+                    else:
+                        selection = remap
+                        block = shard_X
+
+                    # h5py requires a strictly increasing fancy-index selection.
+                    # `selection` follows the shard's own gene order, which is
+                    # rarely sorted, so order the columns and permute the data
+                    # block to match before writing.
+                    if not _is_increasing(selection):
+                        order = np.argsort(selection, kind="stable")
+                        selection = selection[order]
+                        block = block[:, order]
+
                     out_store["X"][  # type: ignore[index]
-                        current_cell : current_cell + num_cells_in_shard, remap
-                    ] = shard_X
+                        current_cell : current_cell + num_cells_in_shard, selection
+                    ] = block
 
             # Stream layers
             for layer in layer_nnz:

--- a/src/annslicer/slice.py
+++ b/src/annslicer/slice.py
@@ -174,7 +174,11 @@ def _shard_store(
             sorted_idx = np.sort(orig_idx)
             restore = np.argsort(np.argsort(orig_idx))
             X = _unwrap(adata.X[sorted_idx, :])[restore]
-            layers = {k: _unwrap(adata.layers[k][sorted_idx, :])[restore] for k in adata.layers if k is not None}
+            layers = {
+                k: _unwrap(adata.layers[k][sorted_idx, :])[restore]
+                for k in adata.layers
+                if k is not None
+            }
             obsm = {k: np.asarray(adata.obsm[k][sorted_idx])[restore] for k in adata.obsm}
             obs = adata.obs.iloc[orig_idx]
             ad.AnnData(

--- a/src/annslicer/slice.py
+++ b/src/annslicer/slice.py
@@ -174,7 +174,7 @@ def _shard_store(
             sorted_idx = np.sort(orig_idx)
             restore = np.argsort(np.argsort(orig_idx))
             X = _unwrap(adata.X[sorted_idx, :])[restore]
-            layers = {k: _unwrap(adata.layers[k][sorted_idx, :])[restore] for k in adata.layers}
+            layers = {k: _unwrap(adata.layers[k][sorted_idx, :])[restore] for k in adata.layers if k is not None}
             obsm = {k: np.asarray(adata.obsm[k][sorted_idx])[restore] for k in adata.obsm}
             obs = adata.obs.iloc[orig_idx]
             ad.AnnData(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -390,6 +390,265 @@ def test_invalid_join_raises(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Unsorted var_names regression tests
+# ---------------------------------------------------------------------------
+#
+# The join tests above use gene names (g0000…g0049) that happen to be in
+# alphabetical order within each shard.  Because Index.union/.intersection
+# return a *sorted* index, those shards produce a monotonically increasing
+# column remap and never exercise the reordering path.
+#
+# Real gene lists are not alphabetically sorted.  When they are not, the remap
+# is non-monotonic, which
+#   * raises "Indexing elements must be in increasing order" from h5py when X
+#     is dense (h5py fancy indexing requires a strictly increasing selection),
+#   * silently writes non-canonical CSR (unsorted column indices within a row)
+#     when X is sparse.
+#
+# Shard order below is deliberately anti-alphabetical.  Note that .union()
+# sorts but .intersection() preserves the calling index's order, so shard B
+# lists the two shared genes in the opposite relative order from shard A to
+# make the inner-join remap non-monotonic as well:
+#
+#   union ['GeneA','GeneM','GeneQ','GeneZ']  remap A [3,1,0]   remap B [0,2,1]
+#   inner ['GeneM','GeneA']                  sel A   [0,1]     sel B   [1,0]
+_UNSORTED_GENES_A = ["GeneZ", "GeneM", "GeneA"]
+_UNSORTED_GENES_B = ["GeneA", "GeneQ", "GeneM"]
+_UNSORTED_UNION = ["GeneA", "GeneM", "GeneQ", "GeneZ"]
+_UNSORTED_INTERSECTION = ["GeneM", "GeneA"]
+
+# Distinct values so that a wrong column permutation cannot pass by accident;
+# the embedded zeros give the sparse shards a different nnz per row.
+_UNSORTED_X_A = np.array([[1.0, 2.0, 3.0], [4.0, 0.0, 6.0]], dtype=np.float32)
+_UNSORTED_X_B = np.array([[7.0, 8.0, 11.0], [0.0, 9.0, 10.0]], dtype=np.float32)
+
+
+def _make_named_shard(
+    tmp_path: Path,
+    name: str,
+    gene_names: list[str],
+    X: np.ndarray,
+    *,
+    sparse: bool,
+) -> str:
+    """Write a shard with an explicit gene order and explicit X values."""
+    adata = ad.AnnData(
+        X=sp.csr_matrix(X) if sparse else X.copy(),
+        obs=pd.DataFrame(index=[f"{name}_cell{i}" for i in range(X.shape[0])]),
+        var=pd.DataFrame(index=gene_names),
+    )
+    path = str(tmp_path / f"{name}.h5ad")
+    adata.write_h5ad(path)
+    return path
+
+
+def _expected_by_gene_name(
+    shards: list[tuple[list[str], np.ndarray]], merged_genes: list[str]
+) -> np.ndarray:
+    """Build the expected merged matrix by gene-name lookup, independent of merge.py."""
+    blocks = []
+    for gene_names, X in shards:
+        pos = {g: j for j, g in enumerate(gene_names)}
+        block = np.zeros((X.shape[0], len(merged_genes)), dtype=np.float32)
+        for k, gene in enumerate(merged_genes):
+            if gene in pos:
+                block[:, k] = X[:, pos[gene]]
+        blocks.append(block)
+    return np.vstack(blocks)
+
+
+def _assert_csr_indices_sorted(path: str, group: str = "X") -> None:
+    """Assert the on-disk CSR has strictly increasing column indices in every row."""
+    with h5py.File(path, "r") as f:
+        indices = f[group]["indices"][:]
+        indptr = f[group]["indptr"][:]
+    for row in range(len(indptr) - 1):
+        row_indices = indices[indptr[row] : indptr[row + 1]]
+        assert np.all(np.diff(row_indices) > 0), (
+            f"row {row} of '{group}' has non-canonical CSR column indices: {row_indices}"
+        )
+
+
+@pytest.fixture()
+def unsorted_dense_pair(tmp_path: Path) -> tuple[str, str]:
+    path_a = _make_named_shard(
+        tmp_path, "unsorted_A", _UNSORTED_GENES_A, _UNSORTED_X_A, sparse=False
+    )
+    path_b = _make_named_shard(
+        tmp_path, "unsorted_B", _UNSORTED_GENES_B, _UNSORTED_X_B, sparse=False
+    )
+    return path_a, path_b
+
+
+@pytest.fixture()
+def unsorted_sparse_pair(tmp_path: Path) -> tuple[str, str]:
+    path_a = _make_named_shard(tmp_path, "sp_A", _UNSORTED_GENES_A, _UNSORTED_X_A, sparse=True)
+    path_b = _make_named_shard(tmp_path, "sp_B", _UNSORTED_GENES_B, _UNSORTED_X_B, sparse=True)
+    return path_a, path_b
+
+
+def test_outer_join_unsorted_var_dense_x(
+    unsorted_dense_pair: tuple[str, str], tmp_path: Path
+) -> None:
+    """Dense X + outer join + non-alphabetical shard var order must not raise.
+
+    Regression test for the reported crash:
+    ``TypeError: Indexing elements must be in increasing order``.
+    """
+    path_a, path_b = unsorted_dense_pair
+    out = str(tmp_path / "unsorted_outer.h5ad")
+    merge_out_of_core([path_a, path_b], out, join="outer")
+
+    merged = ad.read_h5ad(out)
+    assert list(merged.var_names) == _UNSORTED_UNION
+    expected = _expected_by_gene_name(
+        [(_UNSORTED_GENES_A, _UNSORTED_X_A), (_UNSORTED_GENES_B, _UNSORTED_X_B)],
+        _UNSORTED_UNION,
+    )
+    np.testing.assert_array_almost_equal(_to_dense(merged.X), expected)
+
+
+def test_inner_join_unsorted_var_dense_x(
+    unsorted_dense_pair: tuple[str, str], tmp_path: Path
+) -> None:
+    """Dense X + inner join hits the same non-monotonic selection via remap[valid]."""
+    path_a, path_b = unsorted_dense_pair
+    out = str(tmp_path / "unsorted_inner.h5ad")
+    merge_out_of_core([path_a, path_b], out, join="inner")
+
+    merged = ad.read_h5ad(out)
+    assert list(merged.var_names) == _UNSORTED_INTERSECTION
+    expected = _expected_by_gene_name(
+        [(_UNSORTED_GENES_A, _UNSORTED_X_A), (_UNSORTED_GENES_B, _UNSORTED_X_B)],
+        _UNSORTED_INTERSECTION,
+    )
+    np.testing.assert_array_almost_equal(_to_dense(merged.X), expected)
+
+
+def test_outer_join_unsorted_var_sparse_is_canonical_csr(
+    unsorted_sparse_pair: tuple[str, str], tmp_path: Path
+) -> None:
+    """Sparse outer join must write canonical CSR (sorted indices within each row)."""
+    path_a, path_b = unsorted_sparse_pair
+    out = str(tmp_path / "unsorted_outer_sparse.h5ad")
+    merge_out_of_core([path_a, path_b], out, join="outer")
+
+    _assert_csr_indices_sorted(out, "X")
+
+    merged = ad.read_h5ad(out)
+    assert merged.X.has_sorted_indices
+    expected = _expected_by_gene_name(
+        [(_UNSORTED_GENES_A, _UNSORTED_X_A), (_UNSORTED_GENES_B, _UNSORTED_X_B)],
+        _UNSORTED_UNION,
+    )
+    np.testing.assert_array_almost_equal(_to_dense(merged.X), expected)
+
+
+def test_inner_join_unsorted_var_sparse_is_canonical_csr(
+    unsorted_sparse_pair: tuple[str, str], tmp_path: Path
+) -> None:
+    """Sparse inner join must also write canonical CSR."""
+    path_a, path_b = unsorted_sparse_pair
+    out = str(tmp_path / "unsorted_inner_sparse.h5ad")
+    merge_out_of_core([path_a, path_b], out, join="inner")
+
+    _assert_csr_indices_sorted(out, "X")
+
+    merged = ad.read_h5ad(out)
+    assert merged.X.has_sorted_indices
+    expected = _expected_by_gene_name(
+        [(_UNSORTED_GENES_A, _UNSORTED_X_A), (_UNSORTED_GENES_B, _UNSORTED_X_B)],
+        _UNSORTED_INTERSECTION,
+    )
+    np.testing.assert_array_almost_equal(_to_dense(merged.X), expected)
+
+
+def test_outer_join_unsorted_var_dense_x_zarr(
+    unsorted_dense_pair: tuple[str, str], tmp_path: Path
+) -> None:
+    """The same merge to a zarr output stays correct after the reordering fix."""
+    pytest.importorskip("zarr", reason="zarr not installed")
+
+    path_a, path_b = unsorted_dense_pair
+    out = str(tmp_path / "unsorted_outer.zarr")
+    merge_out_of_core([path_a, path_b], out, join="outer")
+
+    merged = ad.read_zarr(out)
+    assert list(merged.var_names) == _UNSORTED_UNION
+    expected = _expected_by_gene_name(
+        [(_UNSORTED_GENES_A, _UNSORTED_X_A), (_UNSORTED_GENES_B, _UNSORTED_X_B)],
+        _UNSORTED_UNION,
+    )
+    np.testing.assert_array_almost_equal(_to_dense(merged.X), expected)
+
+
+def test_duplicate_var_names_raises(tmp_path: Path) -> None:
+    """Duplicate gene names in a remapped shard must fail early with a clear message."""
+    path_a = _make_named_shard(
+        tmp_path,
+        "dup_A",
+        ["GeneZ", "GeneA", "GeneA"],
+        np.array([[1.0, 2.0, 3.0]], dtype=np.float32),
+        sparse=False,
+    )
+    path_b = _make_named_shard(
+        tmp_path,
+        "dup_B",
+        ["GeneQ", "GeneA"],
+        np.array([[4.0, 5.0]], dtype=np.float32),
+        sparse=False,
+    )
+    out = str(tmp_path / "dup.h5ad")
+    with pytest.raises(ValueError, match="duplicate var_names"):
+        merge_out_of_core([path_a, path_b], out, join="outer")
+
+
+def test_duplicate_var_names_error_names_the_shard(tmp_path: Path) -> None:
+    """The duplicate-var_names error identifies the offending shard and gene."""
+    path_a = _make_named_shard(
+        tmp_path,
+        "clean_A",
+        ["GeneZ", "GeneA"],
+        np.array([[1.0, 2.0]], dtype=np.float32),
+        sparse=False,
+    )
+    path_b = _make_named_shard(
+        tmp_path,
+        "dirty_B",
+        ["GeneQ", "GeneQ"],
+        np.array([[4.0, 5.0]], dtype=np.float32),
+        sparse=False,
+    )
+    out = str(tmp_path / "dup2.h5ad")
+    with pytest.raises(ValueError) as excinfo:
+        merge_out_of_core([path_a, path_b], out, join="outer")
+
+    message = str(excinfo.value)
+    assert "dirty_B" in message
+    assert "GeneQ" in message
+    assert "var_names_make_unique" in message
+
+
+def test_duplicate_var_names_allowed_on_identity_fast_path(tmp_path: Path) -> None:
+    """Identical vars need no remapping, so duplicates stay a plain concat (no raise)."""
+    genes = ["GeneZ", "GeneA", "GeneA"]
+    path_a = _make_named_shard(
+        tmp_path, "same_A", genes, np.array([[1.0, 2.0, 3.0]], dtype=np.float32), sparse=False
+    )
+    path_b = _make_named_shard(
+        tmp_path, "same_B", genes, np.array([[4.0, 5.0, 6.0]], dtype=np.float32), sparse=False
+    )
+    out = str(tmp_path / "dup_identity.h5ad")
+    merge_out_of_core([path_a, path_b], out)  # must not raise
+
+    merged = ad.read_h5ad(out)
+    assert list(merged.var_names) == genes
+    np.testing.assert_array_almost_equal(
+        _to_dense(merged.X), np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
+    )
+
+
+# ---------------------------------------------------------------------------
 # CLI glob expansion test
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
If merging (h5ad) files with different `var`, we try to figure out which genes are going to appear in the final file based on the join type.  But when we go to request those columns from the dataset, h5py fancy indexing wants them to be in sorted order.  We were not handling this sorting, and a `TypeError` was raised.

This introduces tests to highlight the problem, and introduces a fix.  It also adds an upfront test for unique var_names if merging is going to join var, and provides a clear error message.